### PR TITLE
Update Amazon IVS Player SDK to 1.4.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '10.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.4.0'
+    pod 'AmazonIVSPlayer', '~> 1.4.1'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.4.0)
+  - AmazonIVSPlayer (1.4.1)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.4.0)
+  - AmazonIVSPlayer (~> 1.4.1)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: e59061ba27a86c3dbfb9db0cacfc49d6abcaeb36
+  AmazonIVSPlayer: 373604429cac7e1bacdac93f7efdddae8d0c8e2f
 
-PODFILE CHECKSUM: e47ecd3c3c0382534dd1a26977f580a69d841a6b
+PODFILE CHECKSUM: 7ae3260a7711a63aeffffcbbd5c01d53bba92eec
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
- Use the latest Amazon IVS Player SDK 1.4.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.