### PR TITLE
Update Amazon IVS Player SDK to 1.5.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '10.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.4.1'
+    pod 'AmazonIVSPlayer', '~> 1.5.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.4.1)
+  - AmazonIVSPlayer (1.5.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.4.1)
+  - AmazonIVSPlayer (~> 1.5.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 373604429cac7e1bacdac93f7efdddae8d0c8e2f
+  AmazonIVSPlayer: 7ab35f4145c3211646fae88fd15604cb89404b62
 
-PODFILE CHECKSUM: 7ae3260a7711a63aeffffcbbd5c01d53bba92eec
+PODFILE CHECKSUM: db72c3433a2cecce23ae9c455aae4c6394fb3415
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.5.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
