### PR TITLE
Update Amazon IVS Player SDK to 1.6.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '10.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.5.0'
+    pod 'AmazonIVSPlayer', '~> 1.6.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.5.0)
+  - AmazonIVSPlayer (1.6.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.5.0)
+  - AmazonIVSPlayer (~> 1.6.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 7ab35f4145c3211646fae88fd15604cb89404b62
+  AmazonIVSPlayer: ffb432b2359faad4d6e91c5c4b9bbe726d42c5af
 
-PODFILE CHECKSUM: db72c3433a2cecce23ae9c455aae4c6394fb3415
+PODFILE CHECKSUM: 22dee0fd74a466457ddec09d70f2b5de628670f6
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.6.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
