### PR TITLE
Update Amazon IVS Player SDK to 1.8.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.7.0'
+    pod 'AmazonIVSPlayer', '~> 1.8.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.
@@ -10,4 +10,4 @@ post_install do |installer|
     installer.pods_project.build_configurations.each do |configuration|
         configuration.build_settings['ARCHS[sdk=iphoneos*]'] = ['$(ARCHS_STANDARD)','arm64e']
     end
- end
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.7.0)
+  - AmazonIVSPlayer (1.8.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.7.0)
+  - AmazonIVSPlayer (~> 1.8.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 8e1afb7f9d9a43a65f3b25ed02bd150e2fb1d41b
+  AmazonIVSPlayer: e4f8df3ece5ff03eb8d557242711476730af294d
 
-PODFILE CHECKSUM: 3294627b261832c31a3ad08596fc4c118986fec2
+PODFILE CHECKSUM: 9307a116638bae0cf5e31c0c4c560f668c602e19
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.8.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
