### PR TITLE
Update Amazon IVS Player SDK to 1.8.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.8.2'
+    pod 'AmazonIVSPlayer', '~> 1.8.3'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.8.2)
+  - AmazonIVSPlayer (1.8.3)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.8.2)
+  - AmazonIVSPlayer (~> 1.8.3)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 5fa9ee5782d3f8e85ddcebf189fa9d9de6ae27e2
+  AmazonIVSPlayer: ce792b427a4fe466d6ea32b3ce8abe391d9242d0
 
-PODFILE CHECKSUM: fccd7cd962e59193a45bae17462e2fb443e014f6
+PODFILE CHECKSUM: 5695c392ed3c6e700b5b1f12835eb64a8e162589
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.8.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
