### PR TITLE
Update Amazon IVS Player SDK to 1.13.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.8.3'
+    pod 'AmazonIVSPlayer', '~> 1.13.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.8.3)
+  - AmazonIVSPlayer (1.13.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.8.3)
+  - AmazonIVSPlayer (~> 1.13.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: ce792b427a4fe466d6ea32b3ce8abe391d9242d0
+  AmazonIVSPlayer: 3c774902428c0893004c59c7bbf9065cc542327c
 
-PODFILE CHECKSUM: 5695c392ed3c6e700b5b1f12835eb64a8e162589
+PODFILE CHECKSUM: 68e6c9edc9ba985029ab48c96fd9d09bf8cf4059
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.13.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
