### PR TITLE
Update Amazon IVS Player SDK to 1.17.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.16.0'
+    pod 'AmazonIVSPlayer', '~> 1.17.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.16.0)
+  - AmazonIVSPlayer (1.17.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.16.0)
+  - AmazonIVSPlayer (~> 1.17.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: e9092086094e70ba1e39b3f6f57f623da05b4b27
+  AmazonIVSPlayer: e64a0a905b60de5760a377eb256895cfae09c694
 
-PODFILE CHECKSUM: f0ff29b9013974284050e0fd0e8e4c9cbb56bef6
+PODFILE CHECKSUM: cfbc35c6bf9e9f02585823aab8a7145c94eec22e
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.17.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
