### PR TITLE
Update Amazon IVS Player SDK to 1.19.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.17.0'
+    pod 'AmazonIVSPlayer', '~> 1.19.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.17.0)
+  - AmazonIVSPlayer (1.19.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.17.0)
+  - AmazonIVSPlayer (~> 1.19.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: e64a0a905b60de5760a377eb256895cfae09c694
+  AmazonIVSPlayer: b9498771b74cd05e93c67dd3844bb4e2c453f2aa
 
-PODFILE CHECKSUM: cfbc35c6bf9e9f02585823aab8a7145c94eec22e
+PODFILE CHECKSUM: 61858885d1e6bdd882580ef1f3fe12bafd9dedb0
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.19.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
