### PR TITLE
Update Amazon IVS Player SDK to 1.20.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.19.0'
+    pod 'AmazonIVSPlayer', '~> 1.20.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.19.0)
+  - AmazonIVSPlayer (1.20.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.19.0)
+  - AmazonIVSPlayer (~> 1.20.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: b9498771b74cd05e93c67dd3844bb4e2c453f2aa
+  AmazonIVSPlayer: 2183a141f179d74251ba041eda22c75cd0f41fc7
 
-PODFILE CHECKSUM: 61858885d1e6bdd882580ef1f3fe12bafd9dedb0
+PODFILE CHECKSUM: cbe6e0851ce6fb3cb4ab335f9ee229b2afa0a008
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.20.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
