### PR TITLE
Update AmazonIVSPlayer to 1.40

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '13.0'
 
 target 'ScrollingFeed' do
-    pod 'AmazonIVSPlayer', '~> 1.38.0'
+    pod 'AmazonIVSPlayer', '~> 1.40.0'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.38.0)
+  - AmazonIVSPlayer (1.40.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.38.0)
+  - AmazonIVSPlayer (~> 1.40.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: a0814406d75cca65998039f63ff9057ab3492b91
+  AmazonIVSPlayer: b1dbf89d0067d016ab734dc6e7ae799ea52101cd
 
-PODFILE CHECKSUM: 5efabca55e9da2089c9469e6d03f3227a831703e
+PODFILE CHECKSUM: c00d87606e77afa165bc57bd74c6ea71c85e5a4f
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.16.2


### PR DESCRIPTION
Update AmazonIVSPlayer to 1.40

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
